### PR TITLE
Rename HDF5.NET to PureHDF.

### DIFF
--- a/HDF5-CSharp/HDF5-CSharp.csproj
+++ b/HDF5-CSharp/HDF5-CSharp.csproj
@@ -162,7 +162,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="HDF.PInvoke.1.10" Version="1.10.612" />
-		<PackageReference Include="HDF5.NET" Version="1.0.0-alpha.18" />
+		<PackageReference Include="PureHDF" Version="1.0.0-alpha.23" />
 		<PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard20'">

--- a/HDF5-CSharp/Hdf5Reader.cs
+++ b/HDF5-CSharp/Hdf5Reader.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
-using HDF5.NET;
+using PureHDF;
 
 namespace HDF5CSharp
 {


### PR DESCRIPTION
Hi @LiorBanai ,

I am working on a beta release of the formerly named HDF.NET project and in this context I had to rename the project because (1) it is annoying to have XXX.NET.XXX namespaces everywhere and more importantly (2) when I type `HDF5.NET` into the browser's address bar, it opens the deprecated `HDF5DotNet` web page from the HDF group.

To avoid that confusion in future I tried to get a better name and this PR makes the required changes on your repository.

Sorry for any inconveniences!