### PR TITLE
Switch to first beta release of PureHDF

### DIFF
--- a/HDF5-CSharp/HDF5-CSharp.csproj
+++ b/HDF5-CSharp/HDF5-CSharp.csproj
@@ -162,7 +162,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="HDF.PInvoke.1.10" Version="1.10.612" />
-		<PackageReference Include="PureHDF" Version="1.0.0-alpha.25" />
+		<PackageReference Include="PureHDF" Version="1.0.0-beta.1" />
 		<PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard20'">

--- a/HDF5-CSharp/Hdf5Reader.cs
+++ b/HDF5-CSharp/Hdf5Reader.cs
@@ -483,7 +483,7 @@ namespace HDF5CSharp
             var flat = ReadFileStructure(fileName).flat;
             return flat;
         }
-        private static void AddAttributes(Hdf5Element element, INativeFile file, bool recursive)
+        private static void AddAttributes(Hdf5Element element, NativeFile file, bool recursive)
         {
             try
             {
@@ -531,20 +531,22 @@ namespace HDF5CSharp
         {
             return (attribute.Type.Class, attribute.Type.Size) switch
             {
-                (H5DataTypeClass.FloatingPoint, 4) => attribute.Read<float>(),
-                (H5DataTypeClass.FloatingPoint, 8) => attribute.Read<double>(),
-                (H5DataTypeClass.FixedPoint, 1) when !attribute.Type.FixedPoint.IsSigned => attribute.Read<byte>(),
-                (H5DataTypeClass.FixedPoint, 1) when attribute.Type.FixedPoint.IsSigned => attribute.Read<sbyte>(),
-                (H5DataTypeClass.FixedPoint, 2) when !attribute.Type.FixedPoint.IsSigned => attribute.Read<ushort>(),
-                (H5DataTypeClass.FixedPoint, 2) when attribute.Type.FixedPoint.IsSigned => attribute.Read<short>(),
-                (H5DataTypeClass.FixedPoint, 4) when !attribute.Type.FixedPoint.IsSigned => attribute.Read<uint>(),
-                (H5DataTypeClass.FixedPoint, 4) when attribute.Type.FixedPoint.IsSigned => attribute.Read<int>(),
-                (H5DataTypeClass.FixedPoint, 8) when !attribute.Type.FixedPoint.IsSigned => attribute.Read<ulong>(),
-                (H5DataTypeClass.FixedPoint, 8) when attribute.Type.FixedPoint.IsSigned => attribute.Read<long>(),
-                (H5DataTypeClass.VariableLength, _) => attribute.ReadString(),
-                (H5DataTypeClass.String, _) => attribute.ReadString(),
+                (H5DataTypeClass.FloatingPoint, 4) => attribute.Read<float[]>(),
+                (H5DataTypeClass.FloatingPoint, 8) => attribute.Read<double[]>(),
+                (H5DataTypeClass.FixedPoint, 1) when !attribute.Type.FixedPoint.IsSigned => attribute.Read<byte[]>(),
+                (H5DataTypeClass.FixedPoint, 1) when attribute.Type.FixedPoint.IsSigned => attribute.Read<sbyte[]>(),
+                (H5DataTypeClass.FixedPoint, 2) when !attribute.Type.FixedPoint.IsSigned => attribute.Read<ushort[]>(),
+                (H5DataTypeClass.FixedPoint, 2) when attribute.Type.FixedPoint.IsSigned => attribute.Read<short[]>(),
+                (H5DataTypeClass.FixedPoint, 4) when !attribute.Type.FixedPoint.IsSigned => attribute.Read<uint[]>(),
+                (H5DataTypeClass.FixedPoint, 4) when attribute.Type.FixedPoint.IsSigned => attribute.Read<int[]>(),
+                (H5DataTypeClass.FixedPoint, 8) when !attribute.Type.FixedPoint.IsSigned => attribute.Read<ulong[]>(),
+                (H5DataTypeClass.FixedPoint, 8) when attribute.Type.FixedPoint.IsSigned => attribute.Read<long[]>(),
+                (H5DataTypeClass.VariableLength, _) => attribute.Read<string[]>(),
+                (H5DataTypeClass.String, _) => attribute.Read<string[]>(),
+                (H5DataTypeClass.Compound, _) => attribute.Read<Dictionary<string, object>>(),
                 // Other types might currently be a bit difficult to read automatically.
-                // However, in future it will be possible to also read unknown structs.
+                // However, in future it will be possible to also read unknown data by simply
+                // calling attribute.Read(). This method will be part of the final release.
                 //
                 // If you need to support more exotic HDF types, you could use reflection
                 // to get the full data type information and not just what is currently


### PR DESCRIPTION
PureHDF is in the beta state with most of the development finished (there is also a lightweight writer implementation now). The API has changed again slightly to enable reading all kind of data. Previously the API was like `T[] dataset.Read<T>(...)` but now you get exactly what you put in for `T`: `T dataset.Read<T>(...)`. So when you want to read a double array, you would do it like this: `dataset.Read<double[]>()` (using square brackets). This also works for multidimensional arrays (`dataset.Read<string[,]>()`), jagged arrays (`dataset.Read<string[][]>()`), compounds (`dataset.Read<YourStructOrObject[]>()`) or unknown compounds (`dataset.Read<Dictionary<string, object>[]>()`).

The new API allows you also to read scalar data by simply ommiting the array brackets: `dataset.Read<string>()`. All values of `T` must be compatible to the HDF5 file type. The compatiblity list (for unknown structs, but this tables applies here also) is here: https://apollo3zehn.github.io/PureHDF/reading/complex.html#unknown-compounds

Unfortunately, I did not think about adding something like `object dataset.Read(...)` where the user does not need to provide a type. The internals of PureHDF already allow this but the API is missing, this will be implemented in the final release (this fall) and will make your attribute reading code (which uses PureHDF) cleaner.

I hope I did not forget any necessary changes as I cannot compile HDF5-CSharp on Linux (may it works somehow but I did no invest much time tying to do it).