### PR TITLE
Allow Nested Compound Types

### DIFF
--- a/HDF5-CSharp/Hdf5Common.cs
+++ b/HDF5-CSharp/Hdf5Common.cs
@@ -174,6 +174,12 @@ namespace HDF5CSharp
                     dataType = H5T.C_S1;
                     break;
                 default:
+                    if (type.IsValueType)
+                    {
+                        dataType = CreateType(type);
+                        break;
+                    }
+
                     throw new ArgumentOutOfRangeException(type.Name, $"Data Type {type} not supported");
             }
             return dataType;


### PR DESCRIPTION
I tried to use compound types in a dataset. My structs contain other structs as datatypes like in the example code below, which was currently not supported by HDF5-CSharp. It failed with an `ArgumentOutOfRangeException` in `Hdf5.GetDataType`.

The proposed changes allow to use nested structs by calling `CreateType`.

```cs
using System.Runtime.InteropServices;
using HDF5CSharp;

var file = Hdf5.CreateFile("test.h5");

var bytes = Hdf5.GetBytes(new CompoundD(42, "abc", new SubS(1, 2)));
var s = Hdf5.fromBytes<CompoundD>(bytes);

Hdf5.WriteCompounds(file, "set1", new[]
{
    new CompoundD(42, "abc", new SubS(1, 2)),
    new CompoundD(21, "def", new SubS(3, 4))
}, new Dictionary<string, List<string>>());

Hdf5.CloseFile(file);

struct CompoundD
{
    public readonly int IntValue;

    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 20)]
    public readonly string StringValue;

    public readonly SubS Sub;

    public CompoundD(int intValue, string stringValue, SubS sub)
    {
        IntValue = intValue;
        StringValue = stringValue;
        Sub = sub;
    }
}

struct SubS
{
    public readonly double Val1;
    public readonly double Val2;

    public SubS(double val1, double val2)
    {
        Val1 = val1;
        Val2 = val2;
    }
}
```